### PR TITLE
You can log in with an incorrect encryption password

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -176,7 +176,7 @@ const metisLogin = (passport, jobs, io) => {
 
         if (!user.validPassword(accounthash)) {
           valid = false;
-          return done(null, false, req.flash('loginMessage', 'Wrong hashphrase'));
+          return done(null, false, req.send({ error: true, message: 'Wrong encryption password' }));
         }
 
         if (valid) {

--- a/config/passport.js
+++ b/config/passport.js
@@ -168,6 +168,12 @@ const metisLogin = (passport, jobs, io) => {
           valid = false;
           return done(null, false, req.flash('loginMessage', 'Account is not registered'));
         }
+
+        if (!user.validEncryptionPassword(containedDatabase.encryptionPassword)) {
+          valid = false;
+          return done(true, null, req.flash('loginMessage', 'Wrong encryption password'));
+        }
+
         if (!user.validPassword(accounthash)) {
           valid = false;
           return done(null, false, req.flash('loginMessage', 'Wrong hashphrase'));
@@ -208,10 +214,10 @@ const metisLogin = (passport, jobs, io) => {
           database: response.database,
           accountData: gravity.encrypt(JSON.stringify(containedDatabase)),
           id: user.data.id,
-          userData : {
+          userData: {
             alias: data.alias,
-            account: data.account
-          }
+            account: data.account,
+          },
         });
       })
       .catch((err) => {

--- a/config/passport.js
+++ b/config/passport.js
@@ -171,12 +171,12 @@ const metisLogin = (passport, jobs, io) => {
 
         if (!user.validEncryptionPassword(containedDatabase.encryptionPassword)) {
           valid = false;
-          return done(true, null, req.flash('loginMessage', 'Wrong encryption password'));
+          return done(true, null, req.send({ error: true, message: 'Wrong encryption password' }));
         }
 
         if (!user.validPassword(accounthash)) {
           valid = false;
-          return done(null, false, req.send({ error: true, message: 'Wrong encryption password' }));
+          return done(null, false, req.flash('loginMessage', 'Wrong hashphrase'));
         }
 
         if (valid) {

--- a/controllers/_application.js
+++ b/controllers/_application.js
@@ -257,28 +257,18 @@ module.exports = (app, passport, React, ReactDOMServer) => {
   // used for the mobile app
   app.post('/appLogin', (req, res, next) => {
     logger.info('\n\n\nappLogin\n\n\n');
-
-    logger.info(req.headers);
-
+    logger.info(JSON.stringify(req.headers));
     logger.info('\n\n\nappLogin\n\n\n');
+
     passport.authenticate('gravity-login', (err, userInfo) => {
       if (err) return next(err);
+
       const accountData = JSON.parse(gravity.decrypt(userInfo.accountData));
-
-      // {
-      //   "account":"JUP-H496-3XEM-94ZH-3R548",
-      //   "accounthash":"JUP-H496-3XEM-94ZH-3R548",
-      //   "encryptionPassword":"damn kitchen play help bare stone greet won wow mirror alas silently",
-      //   "passphrase":"damn kitchen play help bare stone greet won wow mirror alas silently",
-
-      //   "publicKey":"b8fbe029cd72e3a8ee96b6675bb19026f6b0a2bac6c99fccb36443247386ed15",
-      //   "originalTime":1616384679085
-      // }
 
       userInfo.publicKey = accountData.publicKey;
       res.json(userInfo);
     })(req, res, next);
-  })
+  });
 
   // ===============================================================================
   // GET PASSPHRASE

--- a/models/user.js
+++ b/models/user.js
@@ -168,6 +168,12 @@ class User extends Model {
     return bcrypt.compareSync(accounthash, this.record.accounthash);
   }
 
+  validEncryptionPassword(encryptionPassword) {
+    // TODO remove this function once we implement JWT authentication
+    const validFields = encryptionPassword && this.record.encryption_password;
+    return validFields && encryptionPassword === this.record.encryption_password;
+  }
+
   generateKey() {
     const generatedPhrase = methods.generate_keywords();
     const unfilteredKey = bcrypt.hashSync(generatedPhrase, bcrypt.genSaltSync(8), null);


### PR DESCRIPTION
On the login page there is a validation that you have to provide you passphrase and your encryption password, so logging in without the encryption password isn't possible (this validation is still lacking in the (current live) web app).


But I noticed that I also was able to login with providing an incorrect encryption password (this isn't possible on the web app).
Of course you won't see your earlier created channels and this would be very confusing for people. And if they start to create things now, they won't see them later on. As well as, if they would enter an incorrect encryption password the first time they log in, creating channels, log out, then log in with the correct one, they won't see anything at all.

So I really think the same validation as for the web app has to be introduced that it fails to log in when an incorrect encryption password is entered. 